### PR TITLE
Update repository URL:s to point to "standard" org

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.1.0",
   "author": "Jamund Ferguson <jamund@gmail.com>",
   "bugs": {
-    "url": "https://github.com/xjamundx/eslint-plugin-standard/issues"
+    "url": "https://github.com/standard/eslint-plugin-standard/issues"
   },
   "dependencies": {},
   "devDependencies": {
@@ -12,7 +12,7 @@
     "mocha": "^5.1.1",
     "standard": "*"
   },
-  "homepage": "https://github.com/xjamundx/eslint-plugin-standard#readme",
+  "homepage": "https://github.com/standard/eslint-plugin-standard#readme",
   "keywords": [
     "eslint",
     "eslintplugin"
@@ -21,7 +21,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xjamundx/eslint-plugin-standard.git"
+    "url": "git+https://github.com/standard/eslint-plugin-standard.git"
   },
   "scripts": {
     "test": "standard && mocha tests/"

--- a/rules/array-bracket-even-spacing.js
+++ b/rules/array-bracket-even-spacing.js
@@ -15,7 +15,7 @@
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+      url: 'https://github.com/standard/eslint-plugin-standard#rules-explanations'
     }
   },
 

--- a/rules/computed-property-even-spacing.js
+++ b/rules/computed-property-even-spacing.js
@@ -12,7 +12,7 @@
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+      url: 'https://github.com/standard/eslint-plugin-standard#rules-explanations'
     }
   },
 

--- a/rules/no-callback-literal.js
+++ b/rules/no-callback-literal.js
@@ -49,7 +49,7 @@ function couldBeError (node) {
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+      url: 'https://github.com/standard/eslint-plugin-standard#rules-explanations'
     }
   },
 

--- a/rules/object-curly-even-spacing.js
+++ b/rules/object-curly-even-spacing.js
@@ -15,7 +15,7 @@
 module.exports = {
   meta: {
     docs: {
-      url: 'https://github.com/xjamundx/eslint-plugin-standard#rules-explanations'
+      url: 'https://github.com/standard/eslint-plugin-standard#rules-explanations'
     }
   },
 


### PR DESCRIPTION
As a follow up to #24, this PR changes the URL:s in this repository to point to `standard/eslint-plugin-standard` rather than `xjamundx/eslint-plugin-standard` as the latter now redirects to the former anyway.