### PR TITLE
chore(CI): add tests for ESLint 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,55 @@
+name: validate
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  main:
+    strategy:
+      matrix:
+        eslint: [5, 6, 7, 8]
+        node: [6.14, 6, 8, 10, 12, 14, 16]
+        exclude:
+          - eslint: 8
+            node: 10
+          - eslint: 8
+            node: 8
+          - eslint: 8
+            node: 6
+          - eslint: 8
+            node: 6.14
+          - eslint: 7
+            node: 8
+          - eslint: 7
+            node: 6
+          - eslint: 7
+            node: 6.14
+          - eslint: 6
+            node: 6
+          - eslint: 6
+            node: 6.14
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v2
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: 📥 Install ESLint
+        run: npm install eslint@${{ matrix.eslint }}
+
+      - name: ▶️ Run tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+
+# these cause more harm than good
+# when working with contributors
+package-lock.json
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - lts/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-standard",
-  "description": "ESlint Plugin for the Standard Linter",
+  "description": "ESLint Plugin for the Standard Linter",
   "version": "5.0.0",
   "author": {
     "name": "Feross Aboukhadijeh",
@@ -9,12 +9,6 @@
   },
   "bugs": {
     "url": "https://github.com/standard/eslint-plugin-standard/issues"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "eslint": "^7.0.0",
-    "mocha": "^6.2.0",
-    "standard": "*"
   },
   "homepage": "https://github.com/standard/eslint-plugin-standard#readme",
   "keywords": [
@@ -30,8 +24,17 @@
   "scripts": {
     "test": "standard && mocha tests/"
   },
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "mocha": "^6.2.3",
+    "standard": "*"
+  },
   "peerDependencies": {
     "eslint": ">=5.0.0"
+  },
+  "engines": {
+    "node": ">=6.14.0"
   },
   "funding": [
     {


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [ ] [`standard`](https://github.com/standard/standard) (https://github.com/standard/standard/issues/1724)
  - [ ] PR
  - [ ] Release

---

Since Travis is dead, I updated to GitHub Actions

---

Closes #40